### PR TITLE
add linkify option and tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,16 @@ module.exports = function (locals) {
 
   // add author string
   str += ' ';
-  str += (typeof ctx.author === 'string')
-    ? ctx.author
-    : ctx.author.name;
+
+  var author = (typeof ctx.author === 'string') ? ctx.author : ctx.author.name;
+
+  str += author;
+
+  if (ctx.linkify === true && (ctx.author.url || ctx.author.twitter)) {
+    var mdu = require('markdown-utils');
+    var link = mdu.link(author, (ctx.author.url || ctx.author.twitter))
+    str = str.replace(author, link)
+  }
 
   // Keep spaces at the end to ensure that
   // a newline is retained by any md renderer

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "mocha -R spec"
   },
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash": "^2.4.1",
+    "markdown-utils": "^0.1.1"
   },
   "devDependencies": {
     "handlebars": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -10,23 +10,40 @@
 var should = require('should');
 var handlebars = require('handlebars');
 var _ = require('lodash');
-var copyright = require('./');
+var copyrightHelper = require('./');
 
-var locals = {author: {name: 'Jon Schlinkert'}};
+var locals = {author: {name: 'Jon Schlinkert', url: 'https://github.com/jonschlinkert'}};
 
-describe('copyright', function () {
+describe('helper copyright', function () {
   it('should return a formatted copyright statement:', function () {
-    copyright(locals).should.eql('Copyright (c) 2014 Jon Schlinkert  ');
+    copyrightHelper(locals).should.eql('Copyright (c) 2014 Jon Schlinkert  ');
   });
 
   it('should work as a lodash helper:', function () {
-    _.template('<%= copyright({author: author}) %>', locals, {imports: {copyright: copyright}}).should.eql('Copyright (c) 2014 Jon Schlinkert  ');
+    _.template('<%= copyright({author: author}) %>', locals, {imports: {copyright: copyrightHelper}}).should.eql('Copyright (c) 2014 Jon Schlinkert  ');
   });
 
   it('should work as a handlebars helper:', function () {
-    handlebars.registerHelper('copyright', copyright);
+    handlebars.registerHelper('copyright', copyrightHelper);
 
     handlebars.compile('{{copyright this}}')(locals).should.eql('Copyright (c) 2014 Jon Schlinkert  ');
   });
 });
 
+describe('when `linkify` is `true`:', function () {
+  it('should return a formatted copyright statement:', function () {
+    locals = _.extend({linkify: true}, locals);
+    copyrightHelper(locals).should.eql('Copyright (c) 2014 [Jon Schlinkert](https://github.com/jonschlinkert)  ');
+  });
+
+  it('should work as a lodash helper:', function () {
+    _.template('<%= copyright({author: author, linkify: true}) %>', locals, {imports: {copyright: copyrightHelper}}).should.eql('Copyright (c) 2014 [Jon Schlinkert](https://github.com/jonschlinkert)  ');
+  });
+
+  it('should work as a handlebars helper:', function () {
+    locals = _.extend({linkify: true}, locals);
+    handlebars.registerHelper('copyright', copyrightHelper);
+
+    handlebars.compile('{{copyright this}}')(locals).should.eql('Copyright (c) 2014 [Jon Schlinkert](https://github.com/jonschlinkert)  ');
+  });
+});


### PR DESCRIPTION
- add linkify option, same as in `helper-license`
- add test for these cases - copied from `helper-license`, lol
#### Example:

Copyright (c) 2014 [Jon Schlinkert](https://github.com/jonschlinkert)  

works only if `linkify: true` and author is object and have `author.url` or `author.twitter`
